### PR TITLE
feat: implement lazy loading for Dynamo imports and add regression tests

### DIFF
--- a/python/dftracer/python/__init__.py
+++ b/python/dftracer/python/__init__.py
@@ -1,11 +1,27 @@
+import importlib as _importlib
 from importlib.metadata import PackageNotFoundError, version
 
 from dftracer.python.ai import *
-from dftracer.python.dynamo import *
 from dftracer.python.logger import *
+
+_DYNAMO_EXPORTS = {"Dynamo", "dynamo", "create_backend"}
+
+
+def __getattr__(name: str) -> object:
+    if name in _DYNAMO_EXPORTS:
+        dynamo_module = _importlib.import_module("dftracer.python.dynamo")
+        value = getattr(dynamo_module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 try:
     __version__ = version("pydftracer")
 except PackageNotFoundError:
     # package is not installed
     pass
+
+__all__ = [name for name in globals() if not name.startswith("_")]
+for _name in _DYNAMO_EXPORTS:
+    if _name not in __all__:
+        __all__.append(_name)

--- a/python/dftracer/python/dbg/__init__.py
+++ b/python/dftracer/python/dbg/__init__.py
@@ -1,3 +1,21 @@
+import importlib as _importlib
+
 from dftracer.python.dbg.ai import *
 from dftracer.python.dbg.logger import *
-from dftracer.python.dynamo import *
+
+_DYNAMO_EXPORTS = {"Dynamo", "dynamo", "create_backend"}
+
+
+def __getattr__(name: str) -> object:
+    if name in _DYNAMO_EXPORTS:
+        dynamo_module = _importlib.import_module("dftracer.python.dynamo")
+        value = getattr(dynamo_module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [name for name in globals() if not name.startswith("_")]
+for _name in _DYNAMO_EXPORTS:
+    if _name not in __all__:
+        __all__.append(_name)

--- a/python/dftracer/python/dynamo.py
+++ b/python/dftracer/python/dynamo.py
@@ -4,31 +4,37 @@ from typing import Any, Callable, List, Optional, Union, overload
 from dftracer.python.ai_common import DFTracerAI, dftracer
 from dftracer.python.common import DFTRACER_ENABLE, P, R, TagDType, TagType, TagValue
 
-try:
-    import torch
 
-    TORCH_AVAILABLE = True
-except ImportError:
-    TORCH_AVAILABLE = False
-    torch = None  # type: ignore
+def _import_torch() -> Any:
+    try:
+        import torch
+    except ImportError as exc:
+        raise RuntimeError(
+            "PyTorch is not available. Install pydftracer[dynamo] to use Dynamo integration."
+        ) from exc
+    return torch
 
-if TORCH_AVAILABLE:
+
+def _import_autograd_backend() -> Any:
     try:
         from functorch.compile import make_boxed_func
 
         # Alpha feature from: https://docs.pytorch.org/docs/stable/torch.compiler_custom_backends.html#custom-backends-after-aotautograd
         from torch._dynamo.backends.common import aot_autograd
-    except ImportError:
-        if DFTRACER_ENABLE:
-            raise RuntimeError(
-                "DFTracer dynamo requires PyTorch and functorch to be installed"
-            )
-        else:
-            make_boxed_func = None  # type: ignore
-            aot_autograd = None  # type: ignore
-else:
-    make_boxed_func = None  # type: ignore
-    aot_autograd = None  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError(
+            "AOT autograd is not available. Install functorch/torch dependencies or set autograd=False."
+        ) from exc
+    return make_boxed_func, aot_autograd
+
+
+def _is_grad_enabled() -> bool:
+    try:
+        torch = _import_torch()
+    except RuntimeError:
+        return False
+    return bool(torch.is_grad_enabled())
+
 
 CAT_DYNAMO = "dynamo"
 
@@ -88,9 +94,7 @@ class Dynamo(DFTracerAI):
 
     def _record_time_start(self, op_name: str, op_type: str, target: str) -> None:
         timestamp_us = self.get_time()
-        grad_enabled = False
-        if TORCH_AVAILABLE:
-            grad_enabled = torch.is_grad_enabled()
+        grad_enabled = _is_grad_enabled()
         record = CallStackRecord(
             op_name=op_name,
             op_type=op_type,
@@ -175,19 +179,20 @@ class Dynamo(DFTracerAI):
         - Uses PyTorch Dynamo to add nodes before and after each operation
         - The nodes are run before and after each operation -> providing detailed timing information
         """
-        if not TORCH_AVAILABLE:
-            raise RuntimeError(
-                "PyTorch is not available. Install PyTorch to use Dynamo integration."
-            )
-
         if not (DFTRACER_ENABLE and self.enable):  # type: ignore[truthy-function]
-            return f_py  # type: ignore
+            if callable(f_py):
+                return f_py
 
-        if autograd and (aot_autograd is None or make_boxed_func is None):
-            raise RuntimeError(
-                "AOT autograd is not available. Either install required dependencies "
-                "or set autograd=False"
-            )
+            def _passthrough(func: Callable[P, R]) -> Callable[P, R]:
+                return func
+
+            return _passthrough
+
+        torch = _import_torch()
+        make_boxed_func = None
+        aot_autograd = None
+        if autograd:
+            make_boxed_func, aot_autograd = _import_autograd_backend()
 
         def _decorator(func: Callable[P, R]) -> Callable[P, R]:
             def enhanced_trace_wrapper(gm: Any, example: Any, **kwargs: Any) -> Any:
@@ -251,14 +256,19 @@ def create_backend(
         >>> model = torch.nn.Linear(10, 10)
         >>> compiled_model = torch.compile(model, backend=backend)
     """
-    if not TORCH_AVAILABLE:
-        raise RuntimeError("PyTorch is not available")
+    if not (DFTRACER_ENABLE and enable):
 
-    if autograd and (aot_autograd is None or make_boxed_func is None):
-        raise RuntimeError(
-            "AOT autograd is not available. Either install required dependencies "
-            "or set autograd=False"
-        )
+        def backend(gm: Any, _example_inputs: Any, **_kwargs: Any) -> Any:
+            """Backend passthrough when tracing is disabled."""
+            return gm.forward
+
+        return backend
+
+    _import_torch()
+    make_boxed_func = None
+    aot_autograd = None
+    if autograd:
+        make_boxed_func, aot_autograd = _import_autograd_backend()
 
     tracer = Dynamo(
         name=name,

--- a/tests/test_import_regressions.py
+++ b/tests/test_import_regressions.py
@@ -1,0 +1,110 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYTHON_SOURCE = REPO_ROOT / "python"
+
+
+def _run_subprocess(code: str, env_overrides: dict[str, str], timeout: int = 15) -> None:
+    env = os.environ.copy()
+    env.update(env_overrides)
+
+    existing_pythonpath = env.get("PYTHONPATH")
+    if existing_pythonpath:
+        env["PYTHONPATH"] = f"{PYTHON_SOURCE}{os.pathsep}{existing_pythonpath}"
+    else:
+        env["PYTHONPATH"] = str(PYTHON_SOURCE)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    assert result.returncode == 0, (
+        f"Subprocess failed with code {result.returncode}\n"
+        f"STDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}"
+    )
+
+
+@pytest.mark.subprocess
+@pytest.mark.parametrize("enable_value", ["0", "1"])
+def test_base_imports_finish_quickly(enable_value: str) -> None:
+    code = """
+from dftracer.python import ai, dftracer
+print("ok")
+"""
+    _run_subprocess(
+        code,
+        env_overrides={"DFTRACER_ENABLE": enable_value},
+        timeout=15,
+    )
+
+
+@pytest.mark.subprocess
+def test_base_and_lazy_dynamo_import_do_not_import_torch() -> None:
+    code = """
+import sys
+import dftracer.python
+assert "torch" not in sys.modules, sorted(
+    name for name in sys.modules if name.startswith("torch")
+)
+
+from dftracer.python import Dynamo, create_backend, dynamo
+assert dynamo is not None
+assert Dynamo is not None
+assert create_backend is not None
+assert "torch" not in sys.modules, sorted(
+    name for name in sys.modules if name.startswith("torch")
+)
+print("ok")
+"""
+    _run_subprocess(
+        code,
+        env_overrides={"DFTRACER_ENABLE": "1"},
+        timeout=15,
+    )
+
+
+@pytest.mark.subprocess
+def test_dynamo_compile_loads_torch_only_when_explicitly_used() -> None:
+    code = """
+import builtins
+import os
+
+os.environ["DFTRACER_ENABLE"] = "1"
+
+original_import = builtins.__import__
+
+def _blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "torch" or name.startswith("torch."):
+        raise ImportError("blocked torch import for regression test")
+    return original_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = _blocked_import
+
+from dftracer.python import dynamo
+
+try:
+    @dynamo.compile
+    def identity(x):
+        return x
+except RuntimeError as exc:
+    assert "PyTorch is not available" in str(exc), str(exc)
+else:
+    raise AssertionError("Expected RuntimeError when torch import is blocked")
+
+print("ok")
+"""
+    _run_subprocess(
+        code,
+        env_overrides={"DFTRACER_ENABLE": "1"},
+        timeout=15,
+    )


### PR DESCRIPTION
This pull request refactors how the `dynamo` integration is imported and used in the `dftracer.python` package to enable true lazy loading of PyTorch dependencies, improving import performance and robustness when PyTorch is not installed. It also introduces new regression tests to ensure that importing `dftracer.python` does not inadvertently load PyTorch unless explicitly required, and that the lazy import mechanism works as intended.

**Lazy Import Refactor for Dynamo Integration**

* Changed `dftracer.python.__init__.py` and `dftracer.python.dbg.__init__.py` to remove direct imports of `dynamo` and instead expose `Dynamo`, `dynamo`, and `create_backend` via a `__getattr__` hook, enabling lazy loading of PyTorch dependencies. Updated `__all__` to include these exports. [[1]](diffhunk://#diff-02016421f70f8f58c72598d2b919b6ea3dcde39476719ee6ee8db73d3b7e3605R1-R27) [[2]](diffhunk://#diff-92155fb605c27b566339897021f32a4275c3f6158376b3b1960dcb8ec57ffc5aR1-R21)

**Internal Dynamo Implementation Improvements**

* Refactored `dftracer.python.dynamo.py` to replace global import checks with helper functions (`_import_torch`, `_import_autograd_backend`, `_is_grad_enabled`) that raise informative errors only when the functionality is actually used, and removed global state for PyTorch availability.
* Updated methods in `dynamo.py` (`_record_time_start`, `compile`, `create_backend`) to use the new helpers, ensuring that PyTorch and functorch are only imported when needed and that error handling is more precise. [[1]](diffhunk://#diff-32ce79d3703d6a95675023615704269686e2a80ec035aa34eaf95cfb2d977c4dL91-R97) [[2]](diffhunk://#diff-32ce79d3703d6a95675023615704269686e2a80ec035aa34eaf95cfb2d977c4dL178-R195) [[3]](diffhunk://#diff-32ce79d3703d6a95675023615704269686e2a80ec035aa34eaf95cfb2d977c4dL254-R271)

**Testing and Regression Coverage**

* Added new tests in `tests/test_import_regressions.py` to verify that importing `dftracer.python` or accessing its lazy exports does not trigger a PyTorch import, and that errors are correctly raised if PyTorch is unavailable when required.